### PR TITLE
Dependency reviewer - Enabled

### DIFF
--- a/.github/workflows/dependency_enforcement.yml
+++ b/.github/workflows/dependency_enforcement.yml
@@ -1,0 +1,21 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# Reach out on Slack at '#secrity-support' to get help.
+# Link to the action: https://github.com/actions/dependency-review-action
+
+name: "Dependency Review"
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: critical
+          


### PR DESCRIPTION
This PR enables the Dependency Reviewer in your repository. It is enabled to prevent vulnerable dependencies from reaching your codebase. In most cases you will be able to merge this PR as is and start benefiting from its features right away, as a check in each PR. 
However, we encourage you to contact us on `#support-security` on Slack if you have any questions.

We are here to help! :thumbsup:

 - Product Security Engineering team.